### PR TITLE
EVG-9694: migrate to using service users instead of LDAP

### DIFF
--- a/services/cedar.go
+++ b/services/cedar.go
@@ -15,19 +15,20 @@ import (
 
 // DialCedarOptions describes the options for the DialCedar function. The base
 // address defaults to `cedar.mongodb.com` and the RPC port to 7070. If a base
-// address is provided the RPC port must also be provided. The LDAP credentials
-// username and password must always be provided.
+// address is provided the RPC port must also be provided. The username and
+// either password or API key must always be provided.
 type DialCedarOptions struct {
 	BaseAddress string
 	RPCPort     string
 	Username    string
 	Password    string
+	APIKey      string
 	Retries     int
 }
 
 func (opts *DialCedarOptions) validate() error {
-	if opts.Username == "" || opts.Password == "" {
-		return errors.New("must provide username and passowrd")
+	if opts.Username == "" || (opts.Password == "" && opts.APIKey == "") {
+		return errors.New("must provide username and password or API key")
 	}
 
 	if opts.BaseAddress == "" {
@@ -44,7 +45,8 @@ func (opts *DialCedarOptions) validate() error {
 
 type userCredentials struct {
 	Username string `json:"username"`
-	Password string `json:"password"`
+	Password string `json:"password,omitempty"`
+	APIKey   string `json:"api_key,omitempty"`
 }
 
 // DialCedar is a convenience function for creating a RPC client connection
@@ -59,6 +61,7 @@ func DialCedar(ctx context.Context, client *http.Client, opts *DialCedarOptions)
 	creds := &userCredentials{
 		Username: opts.Username,
 		Password: opts.Password,
+		APIKey:   opts.APIKey,
 	}
 	credsPayload, err := json.Marshal(creds)
 	if err != nil {

--- a/services/cedar.go
+++ b/services/cedar.go
@@ -49,6 +49,11 @@ type userCredentials struct {
 	APIKey   string `json:"api_key,omitempty"`
 }
 
+const (
+	APIUserHeader = "Api-User"
+	APIKeyHeader  = "Api-Key"
+)
+
 // DialCedar is a convenience function for creating a RPC client connection
 // with cedar via gRPC.
 func DialCedar(ctx context.Context, client *http.Client, opts *DialCedarOptions) (*grpc.ClientConn, error) {
@@ -60,8 +65,8 @@ func DialCedar(ctx context.Context, client *http.Client, opts *DialCedarOptions)
 
 	apiHeaders := map[string]string{}
 	if opts.Username != "" && opts.APIKey != "" {
-		apiHeaders["Api-User"] = opts.Username
-		apiHeaders["Api-Key"] = opts.APIKey
+		apiHeaders[APIUserHeader] = opts.Username
+		apiHeaders[APIKeyHeader] = opts.APIKey
 	}
 
 	creds := &userCredentials{

--- a/services/cedar.go
+++ b/services/cedar.go
@@ -63,12 +63,6 @@ func DialCedar(ctx context.Context, client *http.Client, opts *DialCedarOptions)
 
 	httpAddress := "https://" + opts.BaseAddress
 
-	apiHeaders := map[string]string{}
-	if opts.Username != "" && opts.APIKey != "" {
-		apiHeaders[APIUserHeader] = opts.Username
-		apiHeaders[APIKeyHeader] = opts.APIKey
-	}
-
 	creds := &userCredentials{
 		Username: opts.Username,
 		Password: opts.Password,
@@ -116,8 +110,8 @@ func makeCedarCertRequest(ctx context.Context, client *http.Client, method, url 
 	req = req.WithContext(ctx)
 
 	if creds != nil && creds.Username != "" && creds.APIKey != "" {
-		req.Header.Set("Api-User", creds.Username)
-		req.Header.Set("Api-Key", creds.APIKey)
+		req.Header.Set(APIUserHeader, creds.Username)
+		req.Header.Set(APIKeyHeader, creds.APIKey)
 	}
 
 	resp, err := client.Do(req)

--- a/services/cedar_test.go
+++ b/services/cedar_test.go
@@ -20,7 +20,7 @@ func TestDialCedarOptionsValidate(t *testing.T) {
 		}
 		assert.Error(t, opts.validate())
 	})
-	t.Run("NoPassword", func(t *testing.T) {
+	t.Run("NoPasswordOrAPIKey", func(t *testing.T) {
 		opts := &DialCedarOptions{
 			BaseAddress: "base",
 			RPCPort:     "9090",
@@ -63,12 +63,27 @@ func TestDialCedarOptionsValidate(t *testing.T) {
 		assert.Equal(t, "password", opts.Password)
 		assert.Equal(t, 10, opts.Retries)
 	})
+	t.Run("ConfiguredOptionsWithAPIKey", func(t *testing.T) {
+		opts := &DialCedarOptions{
+			BaseAddress: "base",
+			RPCPort:     "9090",
+			Username:    "username",
+			APIKey:      "apiKey",
+			Retries:     10,
+		}
+		assert.NoError(t, opts.validate())
+		assert.Equal(t, "base", opts.BaseAddress)
+		assert.Equal(t, "9090", opts.RPCPort)
+		assert.Equal(t, "username", opts.Username)
+		assert.Equal(t, "apiKey", opts.APIKey)
+		assert.Equal(t, 10, opts.Retries)
+	})
 }
 
 func TestDialCedar(t *testing.T) {
 	ctx := context.TODO()
-	username := os.Getenv("LDAP_USER")
-	password := os.Getenv("LDAP_PASSWORD")
+	username := os.Getenv("AUTH_USERNAME")
+	password := os.Getenv("AUTH_PASSWORD")
 
 	t.Run("ConnectToCedar", func(t *testing.T) {
 		opts := &DialCedarOptions{


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-9694

Mostly this just sets the API headers in the requests to that it passes the gimlet user auth middleware.