### PR TITLE
EVG-9694: do not export API key in credentials payload

### DIFF
--- a/services/cedar.go
+++ b/services/cedar.go
@@ -46,7 +46,7 @@ func (opts *DialCedarOptions) validate() error {
 type userCredentials struct {
 	Username string `json:"username"`
 	Password string `json:"password,omitempty"`
-	APIKey   string `json:"api_key,omitempty"`
+	apiKey   string
 }
 
 const (
@@ -66,7 +66,7 @@ func DialCedar(ctx context.Context, client *http.Client, opts *DialCedarOptions)
 	creds := &userCredentials{
 		Username: opts.Username,
 		Password: opts.Password,
-		APIKey:   opts.APIKey,
+		apiKey:   opts.APIKey,
 	}
 
 	ca, err := makeCedarCertRequest(ctx, client, http.MethodGet, httpAddress+"/rest/v1/admin/ca", nil)
@@ -109,9 +109,9 @@ func makeCedarCertRequest(ctx context.Context, client *http.Client, method, url 
 	}
 	req = req.WithContext(ctx)
 
-	if creds != nil && creds.Username != "" && creds.APIKey != "" {
+	if creds != nil && creds.Username != "" && creds.apiKey != "" {
 		req.Header.Set(APIUserHeader, creds.Username)
-		req.Header.Set(APIKeyHeader, creds.APIKey)
+		req.Header.Set(APIKeyHeader, creds.apiKey)
 	}
 
 	resp, err := client.Do(req)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-9694

I decided I'm not going to export the API key for the credentials payload because I want to ensure that the `Api-User` and `Api-Key` headers will correctly authenticate with the gimlet user middleware without relying on cedar's credentials verification (which would also happen if the API key was sent in the credentials payload). This is important, since cedar's LDAP credentials verification (i.e. `checkPayloadCreds()`) will be going away soon.