### PR TITLE
EVG-14557: More granular gRPC middleware auth

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -2,6 +2,7 @@ package aviation
 
 import (
 	"context"
+	"strings"
 
 	"github.com/evergreen-ci/gimlet"
 	"google.golang.org/grpc"
@@ -12,88 +13,82 @@ import (
 // TODO: add interceptors to provide "role required" and "group
 // member" using gimlet.Authenticator
 
-func MakeAuthenticationRequiredUnaryInterceptor(um gimlet.UserManager, conf gimlet.UserMiddlewareConfiguration) grpc.UnaryServerInterceptor {
+func MakeAuthenticationRequiredUnaryInterceptor(um gimlet.UserManager, conf gimlet.UserMiddlewareConfiguration, ignore ...string) grpc.UnaryServerInterceptor {
+	ignoreMap := getIgnoreMap(ignore)
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		meta, ok := metadata.FromIncomingContext(ctx)
-		if !ok {
-			return nil, grpc.Errorf(codes.Unauthenticated, "missing metadata from context")
+		if info == nil || !ignoreMap[info.FullMethod] {
+			var err error
+			if ctx, err = checkUser(ctx, um, conf); err != nil {
+				return nil, err
+			}
 		}
-
-		var (
-			authDataAPIKey string
-			authDataName   string
-		)
-
-		// Grab API auth details from header
-		if len(meta[conf.HeaderKeyName]) > 0 {
-			authDataAPIKey = meta[conf.HeaderKeyName][0]
-		}
-		if len(meta[conf.HeaderUserName]) > 0 {
-			authDataName = meta[conf.HeaderUserName][0]
-		}
-
-		if len(authDataAPIKey) == 0 {
-			return nil, grpc.Errorf(codes.Unauthenticated, "user key not provided")
-		}
-
-		usr, err := um.GetUserByID(authDataName)
-		if err != nil {
-			return nil, grpc.Errorf(codes.Unauthenticated, "problem finding user: %+v", err)
-		}
-
-		if usr == nil {
-			return nil, grpc.Errorf(codes.Unauthenticated, "user not found")
-		}
-
-		if usr.GetAPIKey() != authDataAPIKey {
-			return nil, grpc.Errorf(codes.Unauthenticated, "incorrect credentials")
-		}
-
-		ctx = SetRequestUser(ctx, usr)
 
 		return handler(ctx, req)
 	}
 }
 
-func MakeAuthenticationRequiredStreamInterceptor(um gimlet.UserManager, conf gimlet.UserMiddlewareConfiguration) grpc.StreamServerInterceptor {
-	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) (err error) {
-		ctx := stream.Context()
-
-		meta, ok := metadata.FromIncomingContext(ctx)
-		if !ok {
-			return grpc.Errorf(codes.Unauthenticated, "missing metadata from context")
-		}
-
-		var (
-			authDataAPIKey string
-			authDataName   string
-		)
-
-		// Grab API auth details from header
-		if len(meta[conf.HeaderKeyName]) > 0 {
-			authDataAPIKey = meta[conf.HeaderKeyName][0]
-		}
-		if len(meta[conf.HeaderUserName]) > 0 {
-			authDataName = meta[conf.HeaderUserName][0]
-		}
-
-		if len(authDataAPIKey) == 0 {
-			return grpc.Errorf(codes.Unauthenticated, "user key not provided")
-		}
-
-		usr, err := um.GetUserByID(authDataName)
-		if err != nil {
-			return grpc.Errorf(codes.Unauthenticated, "problem finding user: %+v", err)
-		}
-
-		if usr == nil {
-			return grpc.Errorf(codes.Unauthenticated, "user not found")
-		}
-
-		if usr.GetAPIKey() != authDataAPIKey {
-			return grpc.Errorf(codes.Unauthenticated, "incorrect credentials")
+func MakeAuthenticationRequiredStreamInterceptor(um gimlet.UserManager, conf gimlet.UserMiddlewareConfiguration, ignore ...string) grpc.StreamServerInterceptor {
+	ignoreMap := getIgnoreMap(ignore)
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if info == nil || !ignoreMap[info.FullMethod] {
+			if _, err := checkUser(stream.Context(), um, conf); err != nil {
+				return err
+			}
 		}
 
 		return handler(srv, stream)
 	}
+}
+
+func getIgnoreMap(ignore []string) map[string]bool {
+	ignoreMap := map[string]bool{}
+	for _, method := range ignore {
+		ignoreMap[method] = true
+	}
+
+	return ignoreMap
+}
+
+func checkUser(ctx context.Context, um gimlet.UserManager, conf gimlet.UserMiddlewareConfiguration) (context.Context, error) {
+	meta, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return nil, grpc.Errorf(codes.Unauthenticated, "missing metadata from context")
+	}
+
+	var (
+		authDataAPIKey string
+		authDataName   string
+	)
+
+	// We need to set these to lower case since grpc sets all of
+	// the context metadata keys to lowercase.
+	headerKeyName := strings.ToLower(conf.HeaderKeyName)
+	headerUserName := strings.ToLower(conf.HeaderUserName)
+
+	// Grab API auth details from header.
+	if len(meta[headerKeyName]) > 0 {
+		authDataAPIKey = meta[headerKeyName][0]
+	}
+	if len(meta[headerUserName]) > 0 {
+		authDataName = meta[headerUserName][0]
+	}
+
+	if len(authDataAPIKey) == 0 {
+		return nil, grpc.Errorf(codes.Unauthenticated, "user key not provided")
+	}
+
+	usr, err := um.GetUserByID(authDataName)
+	if err != nil {
+		return nil, grpc.Errorf(codes.Unauthenticated, "finding user: %+v", err)
+	}
+
+	if usr == nil {
+		return nil, grpc.Errorf(codes.Unauthenticated, "user not found")
+	}
+
+	if usr.GetAPIKey() != authDataAPIKey {
+		return nil, grpc.Errorf(codes.Unauthenticated, "incorrect credentials")
+	}
+
+	return SetRequestUser(ctx, usr), nil
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -14,8 +14,8 @@ func TestAuthRequiredInterceptors(t *testing.T) {
 	const (
 		username       = "testUser"
 		userAPIKey     = "123abc"
-		headerUserName = "UserName"
-		headerKeyName  = "KeyName"
+		headerUserName = "user"
+		headerKeyName  = "key"
 	)
 
 	user := gimlet.NewBasicUser(username, "test", "test@test.com", userAPIKey, nil)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14557

Since the health check cannot be protected, I added more granular auth for a gRPC service. This now includes "ignore" methods that cause the middleware to skip auth.