### PR TITLE
EVG-14557: Update dial and cedar service dial options to reflect gRPC auth changes

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 
+	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -31,17 +32,31 @@ type DialOptions struct {
 	// KeyFile is the name of the file with the key certificate for TLS. If
 	// specified, CAFile and CrtFile must also be specified. (Optional)
 	KeyFile string
+	// Username is the username of the API user. If specified, APIKey must
+	// also be specified. (Optional)
+	Username string
+	// APIKey is the API key for user authentication. If specified,
+	// Username must also be specified. (Optional)
+	APIKey string
+	// APIUserHeader is the metadata key for the requester's username. This
+	// must be specified if Username and APIKey are specified. (Optional)
+	APIUserHeader string
+	// APIKeyHeader is the metadata key for the requester's API key. This
+	// must be specified if Username and APIKey are specified. (Optional)
+	APIKeyHeader string
 }
 
 func (opts *DialOptions) validate() error {
-	if opts.Address == "" {
-		return errors.New("must provide rpc address")
-	}
-	if opts.TLSConf == nil && (opts.CAFile == "") != (opts.CrtFile == "") != (opts.KeyFile == "") {
-		return errors.New("must provide all or none of the required certificate filenames")
-	}
+	catcher := grip.NewBasicCatcher()
 
-	return nil
+	catcher.AddWhen(opts.Address == "", errors.New("must provide rpc address"))
+	catcher.AddWhen(
+		((opts.CAFile == "") != (opts.CrtFile == "")) || ((opts.CAFile == "") != (opts.KeyFile == "")),
+		errors.New("must provide all or none of the required certificate filenames"),
+	)
+	catcher.AddWhen((opts.Username == "") != (opts.APIKey == ""), errors.New("must provide or exclude both a username and api key"))
+
+	return catcher.Resolve()
 }
 
 func (opts *DialOptions) getOpts() ([]grpc.DialOption, error) {
@@ -64,11 +79,23 @@ func (opts *DialOptions) getOpts() ([]grpc.DialOption, error) {
 		var err error
 		tlsConf, err = GetClientTLSConfigFromFiles(opts.CAFile, opts.CrtFile, opts.KeyFile)
 		if err != nil {
-			return nil, errors.Wrap(err, "problem getting client TLS config")
+			return nil, errors.Wrap(err, "getting client TLS config")
 		}
 	}
 	if tlsConf != nil {
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConf)))
+	} else {
+		dialOpts = append(dialOpts, grpc.WithInsecure())
+	}
+
+	if opts.Username != "" {
+		dialOpts = append(dialOpts, grpc.WithPerRPCCredentials(&userAuth{
+			username:   opts.Username,
+			apiKey:     opts.APIKey,
+			userHeader: opts.APIUserHeader,
+			keyHeader:  opts.APIKeyHeader,
+			tls:        tlsConf != nil,
+		}))
 	}
 
 	return dialOpts, nil
@@ -78,9 +105,25 @@ func (opts *DialOptions) getOpts() ([]grpc.DialOption, error) {
 func Dial(ctx context.Context, opts DialOptions) (*grpc.ClientConn, error) {
 	dialOpts, err := opts.getOpts()
 	if err != nil {
-		return nil, errors.Wrap(err, "problem getting gRPC dial options")
+		return nil, errors.Wrap(err, "getting gRPC dial options")
 	}
 
 	conn, err := grpc.DialContext(ctx, opts.Address, dialOpts...)
-	return conn, errors.Wrap(err, "problem dialing rpc")
+	return conn, errors.Wrap(err, "dialing rpc")
+}
+
+type userAuth struct {
+	username   string
+	apiKey     string
+	userHeader string
+	keyHeader  string
+	tls        bool
+}
+
+func (a *userAuth) RequireTransportSecurity() bool { return a.tls }
+func (a *userAuth) GetRequestMetadata(ctx context.Context, in ...string) (map[string]string, error) {
+	return map[string]string{
+		a.userHeader: a.username,
+		a.keyHeader:  a.apiKey,
+	}, nil
 }

--- a/dial.go
+++ b/dial.go
@@ -55,6 +55,10 @@ func (opts *DialOptions) validate() error {
 		errors.New("must provide all or none of the required certificate filenames"),
 	)
 	catcher.AddWhen((opts.Username == "") != (opts.APIKey == ""), errors.New("must provide both a username and API key or neither"))
+	catcher.AddWhen(
+		(opts.Username != "" || opts.APIKey != "") && (opts.APIUserHeader == "" || opts.APIKeyHeader == ""),
+		errors.New("must provide an API user header and key header when providing a username and API key"),
+	)
 
 	return catcher.Resolve()
 }

--- a/dial.go
+++ b/dial.go
@@ -54,7 +54,7 @@ func (opts *DialOptions) validate() error {
 		((opts.CAFile == "") != (opts.CrtFile == "")) || ((opts.CAFile == "") != (opts.KeyFile == "")),
 		errors.New("must provide all or none of the required certificate filenames"),
 	)
-	catcher.AddWhen((opts.Username == "") != (opts.APIKey == ""), errors.New("must provide or exclude both a username and api key"))
+	catcher.AddWhen((opts.Username == "") != (opts.APIKey == ""), errors.New("must provide both a username and API key or neither"))
 
 	return catcher.Resolve()
 }

--- a/dial_test.go
+++ b/dial_test.go
@@ -49,6 +49,35 @@ func TestDial(t *testing.T) {
 			hasErr: true,
 		},
 		{
+			name: "UsernameAndAPIKeyNoAPIUserHeader",
+			opts: DialOptions{
+				Address:      "rpcAddress",
+				Username:     "username",
+				APIKey:       "apikey",
+				APIKeyHeader: "api-key",
+			},
+			hasErr: true,
+		},
+		{
+			name: "UsernameAndAPIKeyNoAPIKeyHeader",
+			opts: DialOptions{
+				Address:       "rpcAddress",
+				Username:      "username",
+				APIKey:        "apikey",
+				APIUserHeader: "api-user",
+			},
+			hasErr: true,
+		},
+		{
+			name: "UsernameAndAPIKeyNoHeaders",
+			opts: DialOptions{
+				Address:  "rpcAddress",
+				Username: "username",
+				APIKey:   "apikey",
+			},
+			hasErr: true,
+		},
+		{
 			name: "CertFiles",
 			opts: DialOptions{
 				Address: "rpcAddress",
@@ -69,19 +98,23 @@ func TestDial(t *testing.T) {
 		{
 			name: "UsernameAndAPIKeyWithTLS",
 			opts: DialOptions{
-				Address:  "rpcAddress",
-				TLSConf:  tlsConf,
-				Username: "username",
-				APIKey:   "apikey",
+				Address:       "rpcAddress",
+				TLSConf:       tlsConf,
+				Username:      "username",
+				APIKey:        "apikey",
+				APIUserHeader: "api-user",
+				APIKeyHeader:  "api-key",
 			},
 			expectedOpts: 2,
 		},
 		{
 			name: "UsernameAndAPIKeyNoTLS",
 			opts: DialOptions{
-				Address:  "rpcAddress",
-				Username: "username",
-				APIKey:   "apikey",
+				Address:       "rpcAddress",
+				Username:      "username",
+				APIKey:        "apikey",
+				APIUserHeader: "api-user",
+				APIKeyHeader:  "api-key",
 			},
 			expectedOpts: 2,
 		},

--- a/dial_test.go
+++ b/dial_test.go
@@ -39,6 +39,16 @@ func TestDial(t *testing.T) {
 			hasErr: true,
 		},
 		{
+			name: "MissingCA",
+			opts: DialOptions{
+				Address: "rpcAddress",
+				Retries: 10,
+				CrtFile: filepath.Join("testdata", "user.crt"),
+				KeyFile: filepath.Join("testdata", "user.key"),
+			},
+			hasErr: true,
+		},
+		{
 			name: "CertFiles",
 			opts: DialOptions{
 				Address: "rpcAddress",
@@ -53,6 +63,32 @@ func TestDial(t *testing.T) {
 			opts: DialOptions{
 				Address: "rpcAddress",
 				TLSConf: tlsConf,
+			},
+			expectedOpts: 1,
+		},
+		{
+			name: "UsernameAndAPIKeyWithTLS",
+			opts: DialOptions{
+				Address:  "rpcAddress",
+				TLSConf:  tlsConf,
+				Username: "username",
+				APIKey:   "apikey",
+			},
+			expectedOpts: 2,
+		},
+		{
+			name: "UsernameAndAPIKeyNoTLS",
+			opts: DialOptions{
+				Address:  "rpcAddress",
+				Username: "username",
+				APIKey:   "apikey",
+			},
+			expectedOpts: 2,
+		},
+		{
+			name: "NoAuth",
+			opts: DialOptions{
+				Address: "rpcAddress",
 			},
 			expectedOpts: 1,
 		},

--- a/services/cedar.go
+++ b/services/cedar.go
@@ -3,56 +3,55 @@ package services
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"io"
 	"io/ioutil"
 	"net/http"
 
 	"github.com/evergreen-ci/aviation"
+	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
 
+// API headers for the cedar service.
+const (
+	APIUserHeader = "Api-User"
+	APIKeyHeader  = "Api-Key"
+)
+
 // DialCedarOptions describes the options for the DialCedar function. The base
 // address defaults to `cedar.mongodb.com` and the RPC port to 7070. If a base
-// address is provided the RPC port must also be provided. The username and
-// either password or API key must always be provided.
+// address is provided the RPC port must also be provided. The username and API
+// key must always be provided.
 type DialCedarOptions struct {
 	BaseAddress string
 	RPCPort     string
 	Username    string
-	Password    string
 	APIKey      string
+	TLS         bool
 	Retries     int
 }
 
 func (opts *DialCedarOptions) validate() error {
-	if opts.Username == "" || (opts.Password == "" && opts.APIKey == "") {
-		return errors.New("must provide username and password or API key")
-	}
+	catcher := grip.NewBasicCatcher()
 
 	if opts.BaseAddress == "" {
 		opts.BaseAddress = "cedar.mongodb.com"
 		opts.RPCPort = "7070"
 	}
 
-	if opts.RPCPort == "" {
-		return errors.New("must provide the RPC port")
-	}
+	catcher.AddWhen(opts.Username == "" || opts.APIKey == "", errors.New("must provide username and API key"))
+	catcher.AddWhen(opts.RPCPort == "", errors.New("must provide the RPC port"))
 
-	return nil
+	return catcher.Resolve()
 }
 
 type userCredentials struct {
 	Username string `json:"username"`
-	Password string `json:"password,omitempty"`
 	apiKey   string
 }
-
-const (
-	APIUserHeader = "Api-User"
-	APIKeyHeader  = "Api-Key"
-)
 
 // DialCedar is a convenience function for creating a RPC client connection
 // with cedar via gRPC.
@@ -65,32 +64,38 @@ func DialCedar(ctx context.Context, client *http.Client, opts *DialCedarOptions)
 
 	creds := &userCredentials{
 		Username: opts.Username,
-		Password: opts.Password,
 		apiKey:   opts.APIKey,
 	}
 
-	ca, err := makeCedarCertRequest(ctx, client, http.MethodGet, httpAddress+"/rest/v1/admin/ca", nil)
-	if err != nil {
-		return nil, errors.Wrap(err, "problem getting cedar root cert")
-	}
-	crt, err := makeCedarCertRequest(ctx, client, http.MethodPost, httpAddress+"/rest/v1/admin/users/certificate", creds)
-	if err != nil {
-		return nil, errors.Wrap(err, "problem getting cedar user cert")
-	}
-	key, err := makeCedarCertRequest(ctx, client, http.MethodPost, httpAddress+"/rest/v1/admin/users/certificate/key", creds)
-	if err != nil {
-		return nil, errors.Wrap(err, "problem getting cedar user key")
-	}
+	var tlsConf *tls.Config
+	if opts.TLS {
+		ca, err := makeCedarCertRequest(ctx, client, http.MethodGet, httpAddress+"/rest/v1/admin/ca", nil)
+		if err != nil {
+			return nil, errors.Wrap(err, "getting cedar root cert")
+		}
+		crt, err := makeCedarCertRequest(ctx, client, http.MethodPost, httpAddress+"/rest/v1/admin/users/certificate", creds)
+		if err != nil {
+			return nil, errors.Wrap(err, "getting cedar user cert")
+		}
+		key, err := makeCedarCertRequest(ctx, client, http.MethodPost, httpAddress+"/rest/v1/admin/users/certificate/key", creds)
+		if err != nil {
+			return nil, errors.Wrap(err, "getting cedar user key")
+		}
 
-	tlsConf, err := aviation.GetClientTLSConfig(ca, crt, key)
-	if err != nil {
-		return nil, errors.Wrap(err, "problem creating TLS config")
+		tlsConf, err = aviation.GetClientTLSConfig(ca, crt, key)
+		if err != nil {
+			return nil, errors.Wrap(err, "creating TLS config")
+		}
 	}
 
 	return aviation.Dial(ctx, aviation.DialOptions{
-		Address: opts.BaseAddress + ":" + opts.RPCPort,
-		Retries: opts.Retries,
-		TLSConf: tlsConf,
+		Address:       opts.BaseAddress + ":" + opts.RPCPort,
+		Retries:       opts.Retries,
+		Username:      opts.Username,
+		APIKey:        opts.APIKey,
+		APIUserHeader: APIUserHeader,
+		APIKeyHeader:  APIKeyHeader,
+		TLSConf:       tlsConf,
 	})
 }
 
@@ -105,7 +110,7 @@ func makeCedarCertRequest(ctx context.Context, client *http.Client, method, url 
 	}
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
-		return nil, errors.Wrap(err, "problem creating http request")
+		return nil, errors.Wrap(err, "creating http request")
 	}
 	req = req.WithContext(ctx)
 
@@ -116,13 +121,13 @@ func makeCedarCertRequest(ctx context.Context, client *http.Client, method, url 
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, errors.Wrap(err, "problem with request")
+		return nil, errors.Wrap(err, "creating request")
 	}
 	defer resp.Body.Close()
 
 	out, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, errors.Wrap(err, "problem reading response")
+		return nil, errors.Wrap(err, "reading response")
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/services/cedar_test.go
+++ b/services/cedar_test.go
@@ -15,12 +15,12 @@ func TestDialCedarOptionsValidate(t *testing.T) {
 		opts := &DialCedarOptions{
 			BaseAddress: "base",
 			RPCPort:     "9090",
-			Password:    "password",
+			APIKey:      "apiKey",
 			Retries:     10,
 		}
 		assert.Error(t, opts.validate())
 	})
-	t.Run("NoPasswordOrAPIKey", func(t *testing.T) {
+	t.Run("NoAPIKey", func(t *testing.T) {
 		opts := &DialCedarOptions{
 			BaseAddress: "base",
 			RPCPort:     "9090",
@@ -33,7 +33,7 @@ func TestDialCedarOptionsValidate(t *testing.T) {
 		opts := &DialCedarOptions{
 			BaseAddress: "base",
 			Username:    "username",
-			Password:    "password",
+			APIKey:      "apiKey",
 			Retries:     10,
 		}
 		assert.Error(t, opts.validate())
@@ -41,7 +41,7 @@ func TestDialCedarOptionsValidate(t *testing.T) {
 	t.Run("DefaultBaseAddressAndClient", func(t *testing.T) {
 		opts := &DialCedarOptions{
 			Username: "username",
-			Password: "password",
+			APIKey:   "apiKey",
 			Retries:  10,
 		}
 		assert.NoError(t, opts.validate())
@@ -49,21 +49,6 @@ func TestDialCedarOptionsValidate(t *testing.T) {
 		assert.Equal(t, "7070", opts.RPCPort)
 	})
 	t.Run("ConfiguredOptions", func(t *testing.T) {
-		opts := &DialCedarOptions{
-			BaseAddress: "base",
-			RPCPort:     "9090",
-			Username:    "username",
-			Password:    "password",
-			Retries:     10,
-		}
-		assert.NoError(t, opts.validate())
-		assert.Equal(t, "base", opts.BaseAddress)
-		assert.Equal(t, "9090", opts.RPCPort)
-		assert.Equal(t, "username", opts.Username)
-		assert.Equal(t, "password", opts.Password)
-		assert.Equal(t, 10, opts.Retries)
-	})
-	t.Run("ConfiguredOptionsWithAPIKey", func(t *testing.T) {
 		opts := &DialCedarOptions{
 			BaseAddress: "base",
 			RPCPort:     "9090",
@@ -83,12 +68,13 @@ func TestDialCedarOptionsValidate(t *testing.T) {
 func TestDialCedar(t *testing.T) {
 	ctx := context.TODO()
 	username := os.Getenv("AUTH_USERNAME")
-	password := os.Getenv("AUTH_PASSWORD")
+	apiKey := os.Getenv("API_KEY")
 
 	t.Run("ConnectToCedar", func(t *testing.T) {
 		opts := &DialCedarOptions{
 			Username: username,
-			Password: password,
+			APIKey:   apiKey,
+			TLS:      true,
 			Retries:  10,
 		}
 		conn, err := DialCedar(ctx, http.DefaultClient, opts)
@@ -101,7 +87,8 @@ func TestDialCedar(t *testing.T) {
 			BaseAddress: "cedar.mongo.com",
 			RPCPort:     "7070",
 			Username:    username,
-			Password:    password,
+			APIKey:      apiKey,
+			TLS:         true,
 		}
 		conn, err := DialCedar(ctx, http.DefaultClient, opts)
 		assert.Error(t, err)
@@ -110,7 +97,8 @@ func TestDialCedar(t *testing.T) {
 	t.Run("IncorrectUsernameAndPassword", func(t *testing.T) {
 		opts := &DialCedarOptions{
 			Username: "bad_user",
-			Password: "bad_password",
+			APIKey:   "bad_key",
+			TLS:      true,
 			Retries:  10,
 		}
 		conn, err := DialCedar(ctx, http.DefaultClient, opts)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14557

As we move away from TLS client auth over gRPC we need to update the aviation dial helpers. It is still possible to use TLS for backwards compatibility.