### PR TITLE
EVG-14557: Use system cert pool when cert files are unspecified for cedar

### DIFF
--- a/services/cedar.go
+++ b/services/cedar.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -30,7 +31,8 @@ type DialCedarOptions struct {
 	RPCPort     string
 	Username    string
 	APIKey      string
-	TLS         bool
+	TLSAuth     bool
+	Insecure    bool
 	Retries     int
 }
 
@@ -44,6 +46,7 @@ func (opts *DialCedarOptions) validate() error {
 
 	catcher.AddWhen(opts.Username == "" || opts.APIKey == "", errors.New("must provide username and API key"))
 	catcher.AddWhen(opts.RPCPort == "", errors.New("must provide the RPC port"))
+	catcher.AddWhen(opts.TLSAuth && opts.Insecure, errors.New("cannot use TLS auth over an insecure connection"))
 
 	return catcher.Resolve()
 }
@@ -60,15 +63,14 @@ func DialCedar(ctx context.Context, client *http.Client, opts *DialCedarOptions)
 		return nil, errors.Wrap(err, "invalid dial cedar options")
 	}
 
-	httpAddress := "https://" + opts.BaseAddress
-
-	creds := &userCredentials{
-		Username: opts.Username,
-		apiKey:   opts.APIKey,
-	}
-
 	var tlsConf *tls.Config
-	if opts.TLS {
+	if opts.TLSAuth {
+		httpAddress := "https://" + opts.BaseAddress
+		creds := &userCredentials{
+			Username: opts.Username,
+			apiKey:   opts.APIKey,
+		}
+
 		ca, err := makeCedarCertRequest(ctx, client, http.MethodGet, httpAddress+"/rest/v1/admin/ca", nil)
 		if err != nil {
 			return nil, errors.Wrap(err, "getting cedar root cert")
@@ -86,6 +88,12 @@ func DialCedar(ctx context.Context, client *http.Client, opts *DialCedarOptions)
 		if err != nil {
 			return nil, errors.Wrap(err, "creating TLS config")
 		}
+	} else if !opts.Insecure {
+		certPool, err := x509.SystemCertPool()
+		if err != nil {
+			return nil, errors.Wrap(err, "getting system cert pool")
+		}
+		tlsConf = &tls.Config{RootCAs: certPool}
 	}
 
 	return aviation.Dial(ctx, aviation.DialOptions{

--- a/services/cedar.go
+++ b/services/cedar.go
@@ -44,9 +44,9 @@ func (opts *DialCedarOptions) validate() error {
 		opts.RPCPort = "7070"
 	}
 
-	catcher.AddWhen(opts.Username == "" || opts.APIKey == "", errors.New("must provide username and API key"))
-	catcher.AddWhen(opts.RPCPort == "", errors.New("must provide the RPC port"))
-	catcher.AddWhen(opts.TLSAuth && opts.Insecure, errors.New("cannot use TLS auth over an insecure connection"))
+	catcher.NewWhen(opts.Username == "" || opts.APIKey == "", "must provide username and API key")
+	catcher.NewWhen(opts.RPCPort == "", "must provide the RPC port")
+	catcher.NewWhen(opts.TLSAuth && opts.Insecure, "cannot use TLS auth over an insecure connection")
 
 	return catcher.Resolve()
 }

--- a/services/cedar_test.go
+++ b/services/cedar_test.go
@@ -38,6 +38,17 @@ func TestDialCedarOptionsValidate(t *testing.T) {
 		}
 		assert.Error(t, opts.validate())
 	})
+	t.Run("TLSAuthAndInsecure", func(t *testing.T) {
+		opts := &DialCedarOptions{
+			BaseAddress: "base",
+			Username:    "username",
+			APIKey:      "apiKey",
+			TLSAuth:     true,
+			Insecure:    true,
+			Retries:     10,
+		}
+		assert.Error(t, opts.validate())
+	})
 	t.Run("DefaultBaseAddressAndClient", func(t *testing.T) {
 		opts := &DialCedarOptions{
 			Username: "username",
@@ -74,7 +85,7 @@ func TestDialCedar(t *testing.T) {
 		opts := &DialCedarOptions{
 			Username: username,
 			APIKey:   apiKey,
-			TLS:      true,
+			TLSAuth:  true,
 			Retries:  10,
 		}
 		conn, err := DialCedar(ctx, http.DefaultClient, opts)
@@ -88,7 +99,7 @@ func TestDialCedar(t *testing.T) {
 			RPCPort:     "7070",
 			Username:    username,
 			APIKey:      apiKey,
-			TLS:         true,
+			TLSAuth:     true,
 		}
 		conn, err := DialCedar(ctx, http.DefaultClient, opts)
 		assert.Error(t, err)
@@ -98,7 +109,7 @@ func TestDialCedar(t *testing.T) {
 		opts := &DialCedarOptions{
 			Username: "bad_user",
 			APIKey:   "bad_key",
-			TLS:      true,
+			TLSAuth:  true,
 			Retries:  10,
 		}
 		conn, err := DialCedar(ctx, http.DefaultClient, opts)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14557

So it turns out that the golang gRPC package isn't nice like the http package and requires us to manually create the TLS config instead of just using the system cert pool. Doing this enables to connect to staging (turns out we were trying to connect over HTTP instead of HTTPS).