### PR TITLE
EVG-15479, EVG-15495: remove GO_BIN_PATH and fix linter PATH

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -71,7 +71,7 @@ func (opts *DialOptions) getOpts() ([]grpc.DialOption, error) {
 	}
 
 	dialOpts := []grpc.DialOption{
-		// TODO (PM-2158): After upgrading Go, we should investiage
+		// TODO (PM-2158): After upgrading Go, we should investigate
 		// whether later versions of grpc fixed the following issue
 		// and, if so, upgrade grpc:
 		// Even though we use the default keep alive time of infinity

--- a/makefile
+++ b/makefile
@@ -1,43 +1,58 @@
+# start project configuration
 name := aviation
 buildDir := build
 srcFiles := $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -name "*_test.go" -not -path "*\#*")
-testFiles := $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -path "*\#*")
-
 packages := $(name) services
+# end project configuration
 
 # start environment setup
-gobin := $(GO_BIN_PATH)
-ifeq ($(gobin),)
 gobin := go
-endif
-gopath := $(GOPATH)
-gocache := $(abspath $(buildDir)/.cache)
-goroot := $(GOROOT)
-ifeq ($(OS),Windows_NT)
-gocache := $(shell cygpath -m $(gocache))
-gopath := $(shell cygpath -m $(gopath))
-goroot := $(shell cygpath -m $(goroot))
+ifneq (,$(GOROOT))
+gobin := $(GOROOT)/bin/go
 endif
 
-export GOPATH := $(gopath)
-export GOCACHE := $(gocache)
-export GOROOT := $(goroot)
+ifeq ($(OS),Windows_NT)
+export GOCACHE := $(shell cygpath -m $(abspath $(buildDir)/.cache))
+export GOLANGCI_LINT_CACHE := $(shell cygpath -m $(abspath $(buildDir)/.lint-cache))
+export GOPATH := $(shell cygpath -m $(GOPATH))
+export GOROOT := $(shell cygpath -m $(GOROOT))
+endif
+
 export GO111MODULE := off
 # end environment setup
 
 # Ensure the build directory exists, since most targets require it.
 $(shell mkdir -p $(buildDir))
 
+.DEFAULT_GOAL := compile
+
 # start lint setup targets
 lintDeps := $(buildDir)/golangci-lint $(buildDir)/.lintSetup $(buildDir)/run-linter
 $(buildDir)/golangci-lint:
 	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.40.0 >/dev/null 2>&1 && touch $@
-$(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
+$(buildDir)/run-linter: cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 	$(gobin) build -o $@ $<
 # end lint setup targets
 
+# start output files
+testOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).test)
+lintOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).lint)
+coverageOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage)
+coverageHtmlOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage.html)
+.PRECIOUS: $(coverageOutput) $(coverageHtmlOutput) $(lintOutput) $(testOutput)
+# end output files
 
-# userfacing targets for basic build and development operations
+# start basic development targets
+compile: $(srcFiles)
+	$(gobin) build $(subst $(name),,$(subst -,/,$(foreach target,$(packages),./$(target))))
+test: $(testOutput)
+lint: $(lintOutput)
+coverage: $(coverageOutput)
+coverage-html: $(coverageHtmlOutput)
+phony += compile lint test coverage coverage-html
+
+# start convenience targets for running tests and coverage tasks on a
+# specific package.
 test-%: $(buildDir)/output.%.test
 	
 coverage-%: $(buildDir)/output.%.coverage
@@ -46,16 +61,10 @@ html-coverage-%: $(buildDir)/output.%.coverage.html
 	
 lint-%: $(buildDir)/output.%.lint
 	
+# end convenience targets
+# end basic development targets
 
-compile $(buildDir): $(srcFiles)
-	$(gobin) build $(subst $(name),,$(subst -,/,$(foreach target,$(packages),./$(target))))
-test:$(foreach target,$(packages),$(buildDir)/output.$(target).test)
-	
-lint:$(foreach target,$(packages),$(buildDir)/output.$(target).lint)
-
-.PRECIOUS:$(foreach target,$(packages),$(buildDir)/output.$(target).test)
-.PRECIOUS:$(foreach target,$(packages),$(buildDir)/output.$(target).lint)
-
+# start test and coverage artifacts
 testArgs := -v
 ifneq (,$(RUN_TEST))
 testArgs += -run='$(RUN_TEST)'
@@ -72,26 +81,25 @@ endif
 ifneq (,$(RACE_DETECTOR))
 testArgs += -race
 endif
-
-# test execution and output handlers
-$(buildDir)/output.%.test:$(buildDir) .FORCE
+$(buildDir)/output.%.test: .FORCE
 	$(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) | tee $@
 	@! grep -s -q -e "^FAIL" $@ && ! grep -s -q "^WARNING: DATA RACE" $@
-$(buildDir)/output.%.coverage:$(buildDir) .FORCE
+$(buildDir)/output.%.coverage: .FORCE
 	$(gobin) test $(testArgs) -covermode=count -coverprofile ./$(if $(subst $(name),,$*),$(subst -,/,$*),) | tee $@
 	@-[ -f $@ ] && $(gobin) tool cover -func=$@ | sed 's%$(projectPath)/%%' | column -t
-$(buildDir)/output.%.coverage.html:$(buildDir)/output.%.coverage
+$(buildDir)/output.%.coverage.html: $(buildDir)/output.%.coverage
 	$(gobin) tool cover -html=$< -o $@
-#  targets to generate gotest output from the linter.
-# We have to handle the PATH specially for CI, because if the PATH has a different version of Go in it, it'll break.
-$(buildDir)/output.%.lint:$(buildDir)/run-linter $(buildDir)/ .FORCE
-	@$(if $(GO_BIN_PATH), PATH="$(shell dirname $(GO_BIN_PATH)):$(PATH)") ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$*'
-#  targets to process and generate coverage reports
+
+ifneq (go,$(gobin))
+# We have to handle the PATH specially for linting in CI, because if the PATH has a different version of the Go
+# binary in it, the linter won't work properly.
+lintEnvVars := PATH="$(shell dirname $(gobin)):$(PATH)"
+endif
+$(buildDir)/output.%.lint: $(buildDir)/run-linter .FORCE
+	@$(lintEnvVars) ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$*'
 # end test and coverage artifacts
 
-
 # start vendoring configuration
-#    begin with configuration of dependencies
 vendor-clean:
 	rm -rf vendor/github.com/mongodb/grip/vendor/github.com/stretchr/testify/
 	rm -rf vendor/github.com/mongodb/grip/vendor/github.com/pkg/errors/
@@ -100,18 +108,17 @@ vendor-clean:
 	rm -rf vendor/github.com/evergreen-ci/gimlet/vendor/github.com/pkg/errors/
 	find vendor/ -name "*.gif" -o -name "*.gz" -o -name "*.png" -o -name "*.ico" -o -name "*testdata*" | xargs rm -rf
 phony += vendor-clean
-# end vendoring tooling configuration
+# end vendoring configuration
 
-
+# end cleanup targets
 clean:
-	rm -rf $(lintDeps)
+	rm -rf $(buildDir)
 clean-results:
 	rm -rf $(buildDir)/output.*
-
-phony += lint build test coverage coverage-html
-# end front-ends
+phony += clean clean-results
+# end cleanup targets
 
 
 # configure phony targets
 .FORCE:
-.PHONY:$(phony) .FORCE
+.PHONY: $(phony) .FORCE

--- a/makefile
+++ b/makefile
@@ -22,6 +22,7 @@ endif
 export GOPATH := $(gopath)
 export GOCACHE := $(gocache)
 export GOROOT := $(goroot)
+export GO111MODULE := off
 # end environment setup
 
 # Ensure the build directory exists, since most targets require it.
@@ -30,7 +31,7 @@ $(shell mkdir -p $(buildDir))
 # start lint setup targets
 lintDeps := $(buildDir)/golangci-lint $(buildDir)/.lintSetup $(buildDir)/run-linter
 $(buildDir)/golangci-lint:
-	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.30.0 >/dev/null 2>&1 && touch $@
+	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.40.0 >/dev/null 2>&1 && touch $@
 $(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 	$(gobin) build -o $@ $<
 # end lint setup targets


### PR DESCRIPTION
Jira:
https://jira.mongodb.org/browse/EVG-15479
https://jira.mongodb.org/browse/EVG-15495

* Remove GO_BIN_PATH. CI tests now depend on GOROOT to tell them which Go version to use and which Go binary to use.
* Set the GOLANGCI_LINT_CACHE, which is used to control where golangci-lint caches information. By default, golangci-lint will use the user's cache directory (usually in the home directory). This prevents the CI linter from writing outside of the working directory.
* Fix setting the PATH variable for the linter.
* Clean up and standardize the makefile.