### PR TITLE
EVG-15682: remove DISABLE_COVERAGE flag

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -41,7 +41,7 @@ functions:
       working_dir: ${workdir}/aviation
       binary: make
       args: ["${target}"]
-      include_expansions_in_env: ["DISABLE_COVERAGE", "GOROOT", "RACE_DETECTOR"]
+      include_expansions_in_env: ["GOROOT", "RACE_DETECTOR"]
   parse-results:
     command: gotest.parse_files
     type: setup
@@ -84,7 +84,6 @@ buildvariants:
   - name: lint
     display_name: Lint (Arch Linux)
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
     run_on:
       - archlinux-new-small
@@ -95,7 +94,6 @@ buildvariants:
   - name: ubuntu
     display_name: Ubuntu 18.04
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
     run_on:
       - ubuntu1804-small

--- a/makefile
+++ b/makefile
@@ -103,9 +103,6 @@ endif
 ifneq (,$(SKIP_LONG))
 testArgs += -short
 endif
-ifeq (,$(DISABLE_COVERAGE))
-testArgs += -cover
-endif
 ifneq (,$(RACE_DETECTOR))
 testArgs += -race
 endif


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15682

Remove the `DISABLE_COVERAGE` flag. The only thing that this does is when you run `make test-<package>`, it adds a summary line at the end of the go test output to include the percentage of lines covered that looks like this:
```
coverage:  <N>% of statements
```
I don't think this is particularly useful - instead, it's more useful is to run `make coverage-<package>` or `make html-coverage-<package>`, which produces more detailed information about code coverage rather than a single aggregate coverage number. Those coverage targets do not depend on `DISABLE_COVERAGE`.