### PR TITLE
DEVPROD-7548: reduce keep grpc client alive time

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -3,13 +3,11 @@ package aviation
 import (
 	"context"
 	"crypto/tls"
-	"time"
 
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/keepalive"
 )
 
 // DialOptions describes the options for creating a client connection to a RPC
@@ -70,10 +68,7 @@ func (opts *DialOptions) getOpts() ([]grpc.DialOption, error) {
 		return nil, err
 	}
 
-	dialOpts := []grpc.DialOption{
-		grpc.WithKeepaliveParams(keepalive.ClientParameters{Timeout: 2 * time.Minute}),
-	}
-
+	var dialOpts []grpc.DialOption
 	if opts.Retries > 0 {
 		dialOpts = append(
 			dialOpts,

--- a/dial.go
+++ b/dial.go
@@ -71,14 +71,7 @@ func (opts *DialOptions) getOpts() ([]grpc.DialOption, error) {
 	}
 
 	dialOpts := []grpc.DialOption{
-		// TODO (PM-2158): After upgrading Go, we should investigate
-		// whether later versions of grpc fixed the following issue
-		// and, if so, upgrade grpc:
-		// Even though we use the default keep alive time of infinity
-		// (meaning the client should never send a keep alive ping), we
-		// need a large keep alive timeout for longer running grpc
-		// requests and streams. This is likely a bug in the grpc code.
-		grpc.WithKeepaliveParams(keepalive.ClientParameters{Timeout: 1200 * time.Second}),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{Timeout: 2 * time.Minute}),
 	}
 
 	if opts.Retries > 0 {

--- a/dial_test.go
+++ b/dial_test.go
@@ -85,7 +85,7 @@ func TestDial(t *testing.T) {
 				CrtFile: filepath.Join("testdata", "user.crt"),
 				KeyFile: filepath.Join("testdata", "user.key"),
 			},
-			expectedOpts: 2,
+			expectedOpts: 1,
 		},
 		{
 			name: "TLSConf",
@@ -93,7 +93,7 @@ func TestDial(t *testing.T) {
 				Address: "rpcAddress",
 				TLSConf: tlsConf,
 			},
-			expectedOpts: 2,
+			expectedOpts: 1,
 		},
 		{
 			name: "UsernameAndAPIKeyWithTLS",
@@ -105,7 +105,7 @@ func TestDial(t *testing.T) {
 				APIUserHeader: "api-user",
 				APIKeyHeader:  "api-key",
 			},
-			expectedOpts: 3,
+			expectedOpts: 2,
 		},
 		{
 			name: "UsernameAndAPIKeyNoTLS",
@@ -116,14 +116,14 @@ func TestDial(t *testing.T) {
 				APIUserHeader: "api-user",
 				APIKeyHeader:  "api-key",
 			},
-			expectedOpts: 3,
+			expectedOpts: 2,
 		},
 		{
 			name: "NoAuth",
 			opts: DialOptions{
 				Address: "rpcAddress",
 			},
-			expectedOpts: 2,
+			expectedOpts: 1,
 		},
 		{
 			name: "Retries",
@@ -132,7 +132,7 @@ func TestDial(t *testing.T) {
 				TLSConf: tlsConf,
 				Retries: 15,
 			},
-			expectedOpts: 4,
+			expectedOpts: 3,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
[DEVPROD-7548](https://jira.mongodb.org/browse/DEVPROD-7548)

Reduce the keep alive since this seems to be causing the agent to hang if the Cedar server goes down.